### PR TITLE
Moved test modules updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM python:3.7-slim
 
-WORKDIR /app
+MAINTAINER AlexanderJDupree "https://github.com/AlexanderJDupree"
 
 COPY . /app
 
+WORKDIR /app/newsfeed/
+
 ARG VER=0.0.1
 
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
+RUN pip install --trusted-host pypi.python.org -r /app/requirements.txt
 
-ENTRYPOINT ["python", "newsfeed/newsfeed"]
+ENTRYPOINT ["python"]
+CMD ["newsfeed"]
+

--- a/newsfeed/test/test_parser.py
+++ b/newsfeed/test/test_parser.py
@@ -9,7 +9,7 @@ Author: Alexander DuPree
 import unittest
 import argparse
 
-from newsfeed.helpers import parser
+from helpers import parser
 
 class TestMainParser(unittest.TestCase):
 


### PR DESCRIPTION
Running a docker executable image with the entry point at the top level
of the project was causing some import issues. Moving the test modules
into the newsfeed directory solved this.