### PR TITLE
Added TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+services:
+    - docker
+
+before_install:
+    - docker build -t newsfeed .
+
+script:
+    - docker run newsfeed -m unittest
+


### PR DESCRIPTION
Currently TravisCI is directed to build and run the newsfeed docker container. In the future we should ensure newsfeed can run natively on local machines with different python 3.0+ versions. 